### PR TITLE
Harden namespace checks

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -10,6 +10,7 @@ from src.utils.hub_client import init_hub_client, get_node_id_by_client
 from src.utils.other import extract_hub_envs
 from src.api.oauth import valid_access_token
 from src.resources.database.entity import Database
+from src.k8s.utils import get_current_namespace
 from src.resources.analysis.entity import CreateAnalysis
 from src.resources.log.entity import CreateLogEntity, AnalysisStoppedLog
 from src.resources.utils import (create_analysis,
@@ -42,7 +43,7 @@ class PodOrchestrationAPI:
         namespace: Kubernetes namespace the API operates within.
     """
 
-    def __init__(self, database: Database, namespace: str = 'default'):
+    def __init__(self, database: Database, namespace: Optional[str] = None):
         """Build the FastAPI app, register routes, and start the uvicorn server.
 
         Args:
@@ -56,7 +57,7 @@ class PodOrchestrationAPI:
         self.enable_hub_logging = None
         self._set_node_id_and_hub_client(max_attempts=100)
 
-        self.namespace = namespace
+        self.namespace = namespace or get_current_namespace()
         app = FastAPI(title="FLAME PO",
                       docs_url="/api/docs",
                       redoc_url="/api/redoc",

--- a/src/k8s/kubernetes.py
+++ b/src/k8s/kubernetes.py
@@ -8,7 +8,7 @@ import string
 from kubernetes import client
 
 from src.resources.database.entity import Database
-from src.k8s.utils import find_k8s_resources
+from src.k8s.utils import find_k8s_resources, get_current_namespace
 from src.utils.po_logging import get_logger
 
 
@@ -23,7 +23,7 @@ def create_harbor_secret(host_address: str,
                          user: str,
                          password: str,
                          name: str = 'flame-harbor-credentials',
-                         namespace: str = 'default') -> None:
+                         namespace: Optional[str] = None) -> None:
     """Create (or recreate) the dockerconfigjson secret used to pull analysis images.
 
     If a secret with the same name already exists it is deleted and recreated
@@ -40,6 +40,7 @@ def create_harbor_secret(host_address: str,
         Exception: If the conflict cannot be resolved or an unexpected API
             error occurs.
     """
+    namespace = namespace or get_current_namespace()
     core_client = client.CoreV1Api()
     secret_metadata = client.V1ObjectMeta(name=name, namespace=namespace)
     secret = client.V1Secret(metadata=secret_metadata,
@@ -73,7 +74,7 @@ def create_harbor_secret(host_address: str,
 def create_analysis_deployment(name: str,
                                image: str,
                                env: Optional[dict[str, str]] = None,
-                               namespace: str = 'default') -> list[str]:
+                               namespace: Optional[str] = None) -> list[str]:
     """Deploy an analysis pod along with its nginx sidecar, service, and network policy.
 
     Creates the analysis ``Deployment`` using the Harbor pull secret, exposes
@@ -90,6 +91,7 @@ def create_analysis_deployment(name: str,
     Returns:
         List of pod names that belong to the new analysis deployment.
     """
+    namespace = namespace or get_current_namespace()
     app_client = client.AppsV1Api()
     containers = []
 
@@ -124,10 +126,10 @@ def create_analysis_deployment(name: str,
 
     nginx_name, _ = _create_analysis_nginx_deployment(name, analysis_service_name, env, namespace)
 
-    return _get_pods(name)
+    return _get_pods(name, namespace)
 
 
-def delete_deployment(deployment_name: str, namespace: str = 'default') -> None:
+def delete_deployment(deployment_name: str, namespace: Optional[str] = None) -> None:
     """Tear down an analysis and its companion nginx resources.
 
     Deletes both the analysis and ``nginx-{name}`` deployments with their
@@ -138,6 +140,7 @@ def delete_deployment(deployment_name: str, namespace: str = 'default') -> None:
         deployment_name: Name of the analysis deployment to remove.
         namespace: Namespace the resources live in.
     """
+    namespace = namespace or get_current_namespace()
     logger.action(f"Deleting deployment {deployment_name} in namespace {namespace} at {time.strftime('%Y-%m-%d %H:%M:%S')}")
     app_client = client.AppsV1Api()
     for name in [deployment_name, f'nginx-{deployment_name}']:
@@ -169,7 +172,7 @@ def delete_deployment(deployment_name: str, namespace: str = 'default') -> None:
 
 def get_analysis_logs(deployment_names: dict[str, str],
                       database: Database,
-                      namespace: str = 'default') -> dict[str, dict[str, list[str]]]:
+                      namespace: Optional[str] = None) -> dict[str, dict[str, list[str]]]:
     """Collect pod logs for the analysis and nginx deployments.
 
     Args:
@@ -183,6 +186,7 @@ def get_analysis_logs(deployment_names: dict[str, str],
         Nested mapping ``{'analysis': {analysis_id: [log, ...]},
         'nginx': {analysis_id: [log, ...]}}``.
     """
+    namespace = namespace or get_current_namespace()
     return {'analysis': {analysis_id: _get_logs(name=deployment_name,
                                                 pod_ids=database.get_deployment_pod_ids(deployment_name),
                                                 namespace=namespace)
@@ -193,7 +197,7 @@ def get_analysis_logs(deployment_names: dict[str, str],
             }
 
 
-def get_pod_status(deployment_name: str, namespace: str = 'default') -> Optional[dict[str, dict[str, str]]]:
+def get_pod_status(deployment_name: str, namespace: Optional[str] = None) -> Optional[dict[str, dict[str, str]]]:
     """Return readiness and (if not ready) failure details for each pod in a deployment.
 
     Args:
@@ -204,6 +208,7 @@ def get_pod_status(deployment_name: str, namespace: str = 'default') -> Optional
         Mapping ``{pod_name: {'ready': bool, 'reason': str, 'message': str}}``,
         or ``None`` when no pods or no container statuses are available.
     """
+    namespace = namespace or get_current_namespace()
     core_client = client.CoreV1Api()
 
     # get pods in deployment
@@ -635,7 +640,7 @@ def _delete_service(name: str, namespace: str = 'default') -> None:
     core_client.delete_namespaced_service(async_req=False, name=name, namespace=namespace)
 
 
-def _get_logs(name: str, pod_ids: Optional[list[str]] = None, namespace: str = 'default') -> list[str]:
+def _get_logs(name: str, pod_ids: Optional[list[str]] = None, namespace: Optional[str] = None) -> list[str]:
     """Retrieve and sanitize logs for the pods matching ``app={name}``.
 
     Filters out INFO lines and routine health/webhook access lines, and strips
@@ -649,6 +654,7 @@ def _get_logs(name: str, pod_ids: Optional[list[str]] = None, namespace: str = '
     Returns:
         One sanitized log string per matched pod.
     """
+    namespace = namespace or get_current_namespace()
     core_client = client.CoreV1Api()
     # get pods in deployment
     pods = core_client.list_namespaced_pod(namespace=namespace, label_selector=f'app={name}')
@@ -673,7 +679,7 @@ def _get_logs(name: str, pod_ids: Optional[list[str]] = None, namespace: str = '
     return final_logs
 
 
-def _get_pods(name: str, namespace: str = 'default') -> list[str]:
+def _get_pods(name: str, namespace: Optional[str] = None) -> list[str]:
     """Return pod names matching the ``app={name}`` label selector.
 
     Args:
@@ -683,6 +689,7 @@ def _get_pods(name: str, namespace: str = 'default') -> list[str]:
     Returns:
         List of matching pod names.
     """
+    namespace = namespace or get_current_namespace()
     core_client = client.CoreV1Api()
     return [pod.metadata.name
             for pod in core_client.list_namespaced_pod(namespace=namespace, label_selector=f'app={name}').items]

--- a/src/k8s/utils.py
+++ b/src/k8s/utils.py
@@ -1,5 +1,6 @@
 import time
-from typing import Literal, Optional, Union
+from functools import lru_cache
+from typing import Literal, Optional
 
 from kubernetes import config, client
 
@@ -14,6 +15,7 @@ def load_cluster_config():
     config.load_incluster_config()
 
 
+@lru_cache(maxsize=1)
 def get_current_namespace() -> str:
     """Return the namespace this pod is running in.
 
@@ -95,7 +97,7 @@ def find_k8s_resources(resource_type: str,
     return resource_names
 
 
-def delete_k8s_resource(name: str, resource_type: str, namespace: str = 'default') -> None:
+def delete_k8s_resource(name: str, resource_type: str, namespace: Optional[str] = None) -> None:
     """Delete a Kubernetes resource by name and type.
 
     ``Not Found`` errors are swallowed silently; other API errors are logged.
@@ -109,6 +111,7 @@ def delete_k8s_resource(name: str, resource_type: str, namespace: str = 'default
     Raises:
         ValueError: If ``resource_type`` is not supported.
     """
+    namespace = namespace or get_current_namespace()
     logger.action(f"Deleting resource: {name} of type {resource_type} in namespace {namespace} at {time.strftime('%Y-%m-%d %H:%M:%S')}")
     if resource_type == 'deployment':
         try:

--- a/src/resources/analysis/entity.py
+++ b/src/resources/analysis/entity.py
@@ -9,6 +9,7 @@ from src.resources.database.db_models import AnalysisDB
 from src.resources.database.entity import Database
 from src.status.constants import AnalysisStatus
 from src.utils.mb_client import delete_subscription
+from src.k8s.utils import get_current_namespace
 
 
 class Analysis(BaseModel):
@@ -37,7 +38,7 @@ class Analysis(BaseModel):
     log: Optional[str] = None
     pod_ids: Optional[list[str]] = None
 
-    def start(self, database: Database, namespace: str = 'default') -> None:
+    def start(self, database: Database, namespace: Optional[str] = None) -> None:
         """Deploy the analysis on Kubernetes and persist it in the database.
 
         Generates the deployment name, mints the Kong and Keycloak tokens,
@@ -55,7 +56,7 @@ class Analysis(BaseModel):
         self.analysis_config['ANALYSIS_ID'] = self.analysis_id
         self.analysis_config['PROJECT_ID'] = self.project_id
         self.analysis_config['DEPLOYMENT_NAME'] = self.deployment_name
-        self.namespace = namespace
+        self.namespace = namespace or get_current_namespace()
         database.create_analysis(analysis_id=self.analysis_id,
                                  deployment_name=self.deployment_name,
                                  project_id=self.project_id,
@@ -98,7 +99,7 @@ class Analysis(BaseModel):
         database.update_deployment(self.deployment_name, log=self.log)
         # end message-broker subscription
         self.tokens = create_analysis_tokens(kong_token=self.kong_token, analysis_id=self.analysis_id)
-        delete_subscription(self.analysis_id, self.tokens['KEYCLOAK_TOKEN'])
+        delete_subscription(self.analysis_id, self.tokens['KEYCLOAK_TOKEN'], namespace=self.namespace)
 
 
 def read_db_analysis(analysis: AnalysisDB) -> Analysis:

--- a/src/resources/utils.py
+++ b/src/resources/utils.py
@@ -15,8 +15,7 @@ from src.utils.token import _get_all_keycloak_clients
 from src.utils.token import delete_keycloak_client
 from src.utils.hub_client import (init_hub_client_and_update_hub_status,
                                   update_hub_status,
-                                  get_node_analysis_id,
-                                  get_analysis_node_statuses)
+                                  get_node_analysis_id)
 from src.utils.other import resource_name_to_analysis
 from src.utils.po_logging import get_logger
 from src.utils.other import is_uuid
@@ -144,7 +143,7 @@ def retrieve_logs(analysis_id_str: str, database: Database) -> dict[str, dict[st
             if deployment.status in [AnalysisStatus.EXECUTING.value]:
                 deployment_names[analysis_id] = read_db_analysis(deployment).deployment_name
 
-    return get_analysis_logs(deployment_names, database=database)
+    return get_analysis_logs(deployment_names, database=database, namespace=get_current_namespace())
 
 
 def get_status_and_progress(analysis_id_str: str, database: Database) -> dict[str, dict[str, str]]:
@@ -221,7 +220,7 @@ def stop_analysis(analysis_id_str: str, database: Database) -> dict[str, str]:
 
     for analysis_id, deployment in deployments.items():
         # save logs as string to database (will be read as dict in retrieve_history)
-        log = str(get_analysis_logs({analysis_id: deployment.deployment_name}, database=database))
+        log = str(get_analysis_logs({analysis_id: deployment.deployment_name}, database=database, namespace=get_current_namespace()))
         if deployment.status in [AnalysisStatus.FAILED.value,
                                  AnalysisStatus.EXECUTED.value,
                                  AnalysisStatus.STARTED.value]:

--- a/src/status/status.py
+++ b/src/status/status.py
@@ -389,7 +389,7 @@ def _stream_stuck_logs(analysis: AnalysisDB,
     if is_slow:
         deployment_name = analysis.deployment_name
         # Retrieve status of latest pod
-        pod_status_dict = get_pod_status(deployment_name)
+        pod_status_dict = get_pod_status(deployment_name, get_current_namespace())
         if pod_status_dict is not None:
             _, pod_status_dict = list(pod_status_dict.items())[-1]
             ready, reason, message = pod_status_dict['ready'], pod_status_dict['reason'], pod_status_dict['message']

--- a/src/utils/mb_client.py
+++ b/src/utils/mb_client.py
@@ -1,12 +1,15 @@
+from typing import Optional
+
 from httpx import Client, ConnectError, HTTPStatusError, TimeoutException, ConnectTimeout
-from src.k8s.utils import find_k8s_resources
+from src.k8s.utils import find_k8s_resources, get_current_namespace
 from src.utils.po_logging import get_logger
 
 
 logger = get_logger()
 
 
-def delete_subscription(analysis_id: str, keycloak_token: str, namespace: str = 'default') -> None:
+def delete_subscription(analysis_id: str, keycloak_token: str, namespace: Optional[str] = None) -> None:
+    namespace = namespace or get_current_namespace()
     try:
         # get the service name of the message broker
         message_broker_service_name = find_k8s_resources('service',

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -47,6 +47,13 @@ class TestLoadClusterConfig:
 # ─── get_current_namespace ───────────────────────────────────────────────────
 
 class TestGetCurrentNamespace:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Reset the lru_cache so each test reads a fresh (mocked) namespace file."""
+        get_current_namespace.cache_clear()
+        yield
+        get_current_namespace.cache_clear()
+
     def test_reads_namespace_from_file(self):
         with patch("builtins.open", mock_open(read_data="flame-namespace\n")):
             result = get_current_namespace()

--- a/tests/test_resources_utils.py
+++ b/tests/test_resources_utils.py
@@ -198,7 +198,7 @@ class TestRetrieveLogs:
         retrieve_logs(_ANALYSIS_ID, mock_database)
 
         mock_get_logs.assert_called_once_with(
-            {_ANALYSIS_ID: "analysis-analysis_id-0"}, database=mock_database
+            {_ANALYSIS_ID: "analysis-analysis_id-0"}, database=mock_database, namespace="default"
         )
 
     @patch("src.resources.utils.get_analysis_logs", return_value={"analysis": {}, "nginx": {}})
@@ -211,7 +211,7 @@ class TestRetrieveLogs:
 
         retrieve_logs(_ANALYSIS_ID, mock_database)
 
-        mock_get_logs.assert_called_once_with({}, database=mock_database)
+        mock_get_logs.assert_called_once_with({}, database=mock_database, namespace="default")
 
     @patch("src.resources.utils.get_analysis_logs", return_value={"analysis": {}, "nginx": {}})
     def test_all_analyses(self, mock_get_logs, mock_database, sample_analysis_db):


### PR DESCRIPTION
There were several method calls that took `namespace` as an input parameters, but were not set and fell back to "default" causing the PO to crash when deployed in non-default namespaces with RBAC enabled. This PR updates all methods that use the namespace context to use the `get_current_namespace()` method.

Additionally, to cut down on IO, the `@lru_cache()` decorator was added to the `get_current_namespace()` method since it is called often and this value should not change once deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace handling now follows the current Kubernetes context when one isn’t provided, helping operations run in the correct environment.
  * Log retrieval, pod status checks, deployment actions, and subscription cleanup now use the resolved namespace consistently.
  * Cached namespace lookups are cleared in tests to prevent cross-test interference.

* **Tests**
  * Updated tests to verify namespace-aware log retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->